### PR TITLE
Add test for `get` overloads

### DIFF
--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -371,6 +371,20 @@ TEST(correctness, visit) {
   ASSERT_TRUE(was_called);
 }
 
+TEST(correctness, get) {
+  variant<int, long, double> v(in_place_index<0>, 42);
+
+  ASSERT_EQ(get<0>(v), 42);
+  ASSERT_EQ(get<0>(std::as_const(v)), 42);
+  ASSERT_EQ(get<0>(std::move(v)), 42);
+  ASSERT_EQ(get<0>(std::move(std::as_const(v))), 42);
+
+  ASSERT_EQ(get<int>(v), 42);
+  ASSERT_EQ(get<int>(std::as_const(v)), 42);
+  ASSERT_EQ(get<int>(std::move(v)), 42);
+  ASSERT_EQ(get<int>(std::move(std::as_const(v))), 42);
+}
+
 TEST(correctness, emplace) {
   using V = variant<std::vector<int>, std::string>;
   std::string s = "A fairly long string that will cause an allocation";

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -372,12 +372,12 @@ TEST(correctness, visit) {
 }
 
 TEST(correctness, get) {
-  variant<int, long, double> v(in_place_index<0>, 42);
+  variant<std::string, int, float> v(in_place_index<1>, 42);
 
-  ASSERT_EQ(get<0>(v), 42);
-  ASSERT_EQ(get<0>(std::as_const(v)), 42);
-  ASSERT_EQ(get<0>(std::move(v)), 42);
-  ASSERT_EQ(get<0>(std::move(std::as_const(v))), 42);
+  ASSERT_EQ(get<1>(v), 42);
+  ASSERT_EQ(get<1>(std::as_const(v)), 42);
+  ASSERT_EQ(get<1>(std::move(v)), 42);
+  ASSERT_EQ(get<1>(std::move(std::as_const(v))), 42);
 
   ASSERT_EQ(get<int>(v), 42);
   ASSERT_EQ(get<int>(std::as_const(v)), 42);


### PR DESCRIPTION
Тесты не задейсвуют все перегрузки `get`, мое решение лишь с `get<T>(variant&)` проходит все тесты.